### PR TITLE
Fix error merge manifests

### DIFF
--- a/hermes-eventbus/src/main/AndroidManifest.xml
+++ b/hermes-eventbus/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="xiaofei.library.hermeseventbus">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application>
         <service android:name="HermesEventBus$Service"/>
     </application>
 


### PR DESCRIPTION
Error:Execution failed for task ':Libs:AndroidPromotion:processDebugAndroidTestManifest'.

> java.lang.RuntimeException: Manifest merger failed : Attribute application@supportsRtl value=(false) from manifestMerger8659928865173526062.xml:23:9-36
>     is also present at [xiaofei.library:hermes-eventbus:0.1.1] AndroidManifest.xml:14:9-35 value=(true).
>     Suggestion: add 'tools:replace="android:supportsRtl"' to <application> element at manifestMerger8659928865173526062.xml:18:5-46:19 to override.
